### PR TITLE
Codestyle revisado para mais próximo dos padrões PSR1/PSR2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.{php,phtml}]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/app/code/community/Freterapido/Freterapido/Helper/Data.php
+++ b/app/code/community/Freterapido/Freterapido/Helper/Data.php
@@ -7,7 +7,6 @@
  * @copyright Frete Rápido (https://freterapido.com)
  * @license https://github.com/freterapido/freterapido_magento/blob/master/LICENSE MIT
  */
-
 class Freterapido_Freterapido_Helper_Data extends Mage_Core_Helper_Abstract
 {
     const CODE = 'freterapido';

--- a/app/code/community/Freterapido/Freterapido/Model/Attribute/Source/Categoriesfr.php
+++ b/app/code/community/Freterapido/Freterapido/Model/Attribute/Source/Categoriesfr.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @category Freterapido
  * @package Freterapido_Freterapido
@@ -6,12 +7,13 @@
  * @copyright Frete Rápido (https://freterapido.com)
  * @license https://github.com/freterapido/freterapido_magento/blob/master/LICENSE MIT
  */
-
 class Freterapido_Freterapido_Model_Source_Categoriesfr extends Mage_Eav_Model_Entity_Attribute_Source_Abstract
 {
     protected $_options = null;
-    public function getAllOptions($withEmpty = false){
-        if (is_null($this->_options)){
+
+    public function getAllOptions($withEmpty = false)
+    {
+        if (is_null($this->_options)) {
             $this->_options = array();
 
             $this->_options[] = array('label' => 'Abrasivos', 'value' => 1);

--- a/app/code/community/Freterapido/Freterapido/Model/Observer.php
+++ b/app/code/community/Freterapido/Freterapido/Model/Observer.php
@@ -7,7 +7,6 @@
  * @copyright Frete Rápido (https://freterapido.com)
  * @license https://github.com/freterapido/freterapido_magento/blob/master/LICENSE MIT
  */
-
 class Freterapido_Freterapido_Model_Observer extends Mage_Core_Model_Abstract
 {
     const CODE = 'freterapido';
@@ -48,8 +47,9 @@ class Freterapido_Freterapido_Model_Observer extends Mage_Core_Model_Abstract
         $active = (boolean) Mage::helper($this->_code)->getConfigData('active');
 
         // Se o módulo não estiver ativo, ignora a contratação pelo Frete Rápido
-        if (!$active)
+        if (!$active) {
             return false;
+        }
 
         $_shipment = $observer->getEvent()->getShipment();
 
@@ -65,16 +65,15 @@ class Freterapido_Freterapido_Model_Observer extends Mage_Core_Model_Abstract
             // Verifica se o checkout foi feito com o usuário logado ou não, pois a forma de obter o cnpj/cpf é diferente em cada caso
             if (!empty($_customer_id)) {
                 $_cnpj_cpf = Mage::getModel('customer/customer')->load($_customer_id)->getData('taxvat');
-
             } elseif (!empty($_vat_id)) {
                 $_cnpj_cpf = $_vat_id;
-
             } else {
                 $_cnpj_cpf = $_order->getData('customer_taxvat');
             }
 
-            if (empty($_cnpj_cpf))
+            if (empty($_cnpj_cpf)) {
                 throw new Exception('O CNPJ/CPF do destinatário não foi informado.');
+            }
 
             $_cnpj_cpf = preg_replace("/\D/", '', $_cnpj_cpf);
 
@@ -86,8 +85,11 @@ class Freterapido_Freterapido_Model_Observer extends Mage_Core_Model_Abstract
 
             $this->_getOffer($_order->getShippingMethod());
 
-            $this->_url = sprintf(Mage::helper($this->_code)->getConfigData('api_quote_url'),
-                $this->_offer['token'], $this->_offer['code'], Mage::helper($this->_code)->getConfigData('token')
+            $this->_url = sprintf(
+                Mage::helper($this->_code)->getConfigData('api_quote_url'),
+                $this->_offer['token'],
+                $this->_offer['code'],
+                Mage::helper($this->_code)->getConfigData('token')
             );
 
             $this->_doHire();
@@ -112,7 +114,6 @@ class Freterapido_Freterapido_Model_Observer extends Mage_Core_Model_Abstract
 
             $this->_sender = array();
             $this->_sender['cnpj'] = Mage::getStoreConfig('carriers/freterapido/shipper_cnpj');
-
         } catch (Exception $e) {
             $this->_throwError('Erro ao tentar obter os dados de origem. Erro: ' . $e->getMessage());
         }
@@ -125,9 +126,9 @@ class Freterapido_Freterapido_Model_Observer extends Mage_Core_Model_Abstract
     protected function _getReceiver($order, $cnpj_cpf)
     {
         try {
-            $name = $order->getShippingAddress()->getFirstname() .
-                ' ' .
-                $order->getShippingAddress()->getLastname();
+            $name = $order->getShippingAddress()->getFirstname()
+                .' '
+                .$order->getShippingAddress()->getLastname();
 
             $this->_receiver = array();
             $this->_receiver['cnpj_cpf'] = preg_replace("/\D/", '', $cnpj_cpf);
@@ -137,7 +138,6 @@ class Freterapido_Freterapido_Model_Observer extends Mage_Core_Model_Abstract
 
             $this->_receiver['endereco']['cep'] = $this->_formatZipCode($order->getShippingAddress()->getPostcode());
             $this->_receiver['endereco']['rua'] = $order->getShippingAddress()->getData('street');
-
         } catch (Exception $e) {
             $this->_throwError('Erro ao tentar obter os dados de origem. Erro: ' . $e->getMessage());
         }
@@ -154,7 +154,7 @@ class Freterapido_Freterapido_Model_Observer extends Mage_Core_Model_Abstract
         $new_zipcode = preg_replace("/\D/", '', trim($zipcode));
 
         if (strlen($new_zipcode) !== 8) {
-           throw new Exception('O CEP digitado é inválido');
+            throw new Exception('O CEP digitado é inválido');
         }
 
         return $new_zipcode;
@@ -247,7 +247,6 @@ class Freterapido_Freterapido_Model_Observer extends Mage_Core_Model_Abstract
     {
         Mage::log('Frete Rápido: ' . $mensagem);
     }
-
 
     /**
      * Armazena no log a mensagem informada

--- a/app/code/community/Freterapido/Freterapido/Model/Resource/Setup.php
+++ b/app/code/community/Freterapido/Freterapido/Model/Resource/Setup.php
@@ -1,3 +1,6 @@
 <?php
-	class Freterapido_Freterapido_Model_Resource_Setup extends Mage_Core_Model_Resource_Setup {
-	}
+
+class Freterapido_Freterapido_Model_Resource_Setup extends Mage_Core_Model_Resource_Setup
+{
+    //
+}

--- a/app/code/community/Freterapido/Freterapido/Model/Source/Frcategory.php
+++ b/app/code/community/Freterapido/Freterapido/Model/Source/Frcategory.php
@@ -7,12 +7,13 @@
 * @copyright Frete Rápido (https://freterapido.com)
 * @license https://github.com/freterapido/freterapido_magento/blob/master/LICENSE MIT
 */
-
 class Freterapido_Freterapido_Model_Source_Frcategory extends Mage_Eav_Model_Entity_Attribute_Source_Abstract
 {
     protected $_options = null;
-    public function getAllOptions($withEmpty = false){
-        if (is_null($this->_options)){
+
+    public function getAllOptions($withEmpty = false)
+    {
+        if (is_null($this->_options)) {
             $this->_options = array();
 
             $this->_options[] = array('label' => 'Abrasivos', 'value' => 1);
@@ -89,14 +90,17 @@ class Freterapido_Freterapido_Model_Source_Frcategory extends Mage_Eav_Model_Ent
             $this->_options[] = array('label' => 'Vestuário', 'value' => 60);
             $this->_options[] = array('label' => 'Vidros / Frágil', 'value' => 61);
             $this->_options[] = array('label' => 'Outros', 'value' => 999);
-            $options = $this->_options;
         }
+
         $options = $this->_options;
+
         if ($withEmpty) {
             array_unshift($options, array('value'=>'', 'label'=>'-- Selecione --'));
         }
+
         return $options;
     }
+
     public function getOptionText($value)
     {
         $options = $this->getAllOptions(false);
@@ -106,6 +110,7 @@ class Freterapido_Freterapido_Model_Source_Frcategory extends Mage_Eav_Model_Ent
                 return $item['label'];
             }
         }
+
         return false;
     }
 }

--- a/app/code/community/Freterapido/Freterapido/Model/Source/LimitOptions.php
+++ b/app/code/community/Freterapido/Freterapido/Model/Source/LimitOptions.php
@@ -7,7 +7,6 @@
  * @copyright Frete Rápido (https://freterapido.com)
  * @license https://github.com/freterapido/freterapido_magento/blob/master/LICENSE MIT
  */
-
 class Freterapido_Freterapido_Model_Source_LimitOptions
 {
     /**
@@ -17,7 +16,6 @@ class Freterapido_Freterapido_Model_Source_LimitOptions
      */
     public function toOptionArray()
     {
-
         $array = array();
 
         foreach (range(1, 20) as $number) {
@@ -25,6 +23,5 @@ class Freterapido_Freterapido_Model_Source_LimitOptions
         }
 
         return $array;
-
     }
 }

--- a/app/code/community/Freterapido/Freterapido/Model/Source/ResultOptions.php
+++ b/app/code/community/Freterapido/Freterapido/Model/Source/ResultOptions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This source file is subject to the MIT License.
  * It is also available through http://opensource.org/licenses/MIT
@@ -11,7 +12,6 @@
  */
 class Freterapido_Freterapido_Model_Source_ResultOptions
 {
-
     /**
      * Get options for weight
      *

--- a/app/code/community/Freterapido/Freterapido/Model/Source/WeightType.php
+++ b/app/code/community/Freterapido/Freterapido/Model/Source/WeightType.php
@@ -10,7 +10,6 @@
 
 class Freterapido_Freterapido_Model_Source_WeightType
 {
-
     // Get the constants of Kilos or Grams
     const WEIGHT_IN_KG = 'kg';
     const WEIGHT_IN_GR = 'gr';

--- a/app/code/community/Freterapido/Freterapido/Model/Tracking.php
+++ b/app/code/community/Freterapido/Freterapido/Model/Tracking.php
@@ -7,7 +7,6 @@
  * @copyright Frete Rápido (https://freterapido.com)
  * @license https://github.com/freterapido/freterapido_magento/blob/master/LICENSE MIT
  */
-
 class Freterapido_Freterapido_Model_Tracking
 {
     const CODE = 'freterapido';
@@ -72,11 +71,9 @@ class Freterapido_Freterapido_Model_Tracking
                 // Seta os status do tracking para retornar no front
                 $tracking = $this->_setTrackingProgress($progress);
                 $this->_result->append($tracking);
-
             } else {
                 throw new Exception('Nenhuma ocorrência foi encontrada para o frete ' . $this->_tracking_number);
             }
-
         } catch (Exception $e) {
             $this->_log($e->getMessage());
             $this->_result->append($error);
@@ -124,8 +121,9 @@ class Freterapido_Freterapido_Model_Tracking
     {
         $progress = array();
 
-        if (empty($occurrences))
+        if (empty($occurrences)) {
             return false;
+        }
 
         foreach ($occurrences as $occurrence) {
             $date = new DateTime($occurrence->data_ocorrencia);

--- a/app/code/community/Freterapido/Freterapido/sql/freterapido_setup/mysql4-install-1.0.7.php
+++ b/app/code/community/Freterapido/Freterapido/sql/freterapido_setup/mysql4-install-1.0.7.php
@@ -7,8 +7,6 @@
  * @copyright Frete Rápido (https://freterapido.com)
  * @license https://github.com/freterapido/freterapido_magento/blob/master/LICENSE MIT
 */
-
-
 $installer = $this;
 
 $setup = new Mage_Eav_Model_Entity_Setup('core_setup');
@@ -86,16 +84,14 @@ $attributes = array(
     'fr_volume_prazo_fabricacao'
 );
 
-foreach ( $setIds as $setId ) {
-
+foreach ($setIds as $setId) {
     $setup->addAttributeGroup('catalog_product', $setId, 'Frete Rápido', 2);
     $groupId = $setup->getAttributeGroupId('catalog_product', $setId, 'Frete Rápido');
 
-    foreach ( $attributes as $attribute ) {
+    foreach ($attributes as $attribute) {
         $attributeId = $setup->getAttributeId('catalog_product', $attribute);
         $setup->addAttributeToGroup('catalog_product', $setId, $groupId, $attributeId);
     }
-
 }
 
 $installer->endSetup();

--- a/app/code/community/Freterapido/ProductPageShipping/Block/Estimate/Abstract.php
+++ b/app/code/community/Freterapido/ProductPageShipping/Block/Estimate/Abstract.php
@@ -23,14 +23,12 @@ abstract class Freterapido_ProductPageShipping_Block_Estimate_Abstract extends M
      */
     protected $_estimate = null;
 
-
     /**
      * Config model
      *
      * @var Freterapido_ProductPageShipping_Model_Config
      */
     protected $_config = null;
-
 
     /**
      * Module session model

--- a/app/code/community/Freterapido/ProductPageShipping/Block/Estimate/Form.php
+++ b/app/code/community/Freterapido/ProductPageShipping/Block/Estimate/Form.php
@@ -45,6 +45,7 @@ class Freterapido_ProductPageShipping_Block_Estimate_Form extends Freterapido_Pr
     public function getFieldValue($fieldName)
     {
         $values = $this->getSession()->getFormValues();
+
         if (isset($values[$fieldName])) {
             return $values[$fieldName];
         }
@@ -110,8 +111,7 @@ class Freterapido_ProductPageShipping_Block_Estimate_Form extends Freterapido_Pr
      */
     public function useShoppingCart()
     {
-        if ($this->getSession()->getFormValues() === null ||
-            !$this->isFieldVisible('cart')) {
+        if ($this->getSession()->getFormValues() === null || !$this->isFieldVisible('cart')) {
             return $this->getConfig()->useCartDefault();
         }
 

--- a/app/code/community/Freterapido/ProductPageShipping/Helper/Data.php
+++ b/app/code/community/Freterapido/ProductPageShipping/Helper/Data.php
@@ -25,7 +25,7 @@ class Freterapido_ProductPageShipping_Helper_Data extends Mage_Core_Helper_Abstr
     {
         return Mage::getSingleton('freterapido_productpageshipping/config');
     }
-    
+
     /**
      * Retieve display positioning logic flag
      *
@@ -35,9 +35,9 @@ class Freterapido_ProductPageShipping_Helper_Data extends Mage_Core_Helper_Abstr
     {
         return $this->_getConfig()->getDisplayPositionFlag();
     }
-    
+
     /**
-     * Retieve display positioning block, 
+     * Retieve display positioning block,
      * e.g. related sibling element for positioning
      *
      * @return string
@@ -46,5 +46,4 @@ class Freterapido_ProductPageShipping_Helper_Data extends Mage_Core_Helper_Abstr
     {
         return $this->_getConfig()->getDisplayPositionBlock();
     }
-    
 }

--- a/app/code/community/Freterapido/ProductPageShipping/Model/Config.php
+++ b/app/code/community/Freterapido/ProductPageShipping/Model/Config.php
@@ -136,8 +136,8 @@ class Freterapido_ProductPageShipping_Model_Config
     {
         return Mage::getStoreConfig(self::XML_PATH_DISPLAY_POSITION);
     }
-    
-    
+
+
     /**
      * Retieve display positioning logic flag
      *
@@ -147,9 +147,9 @@ class Freterapido_ProductPageShipping_Model_Config
     {
         return Mage::getStoreConfigFlag(self::XML_PATH_DISPLAY_POSITION_FLAG);
     }
-    
+
     /**
-     * Retieve display positioning block, 
+     * Retieve display positioning block,
      * e.g. related sibling element for positioning
      *
      * @return string
@@ -158,10 +158,10 @@ class Freterapido_ProductPageShipping_Model_Config
     {
         return Mage::getStoreConfig(self::XML_PATH_DISPLAY_POSITION_BLOCK);
     }
-    
+
     /**
      * Returns position source model
-     * 
+     *
      * @return Freterapido_ProductPageShipping_Model_Config_Source_Position
      */
     public function getPositionSource()

--- a/app/code/community/Freterapido/ProductPageShipping/Model/Config/Source/Position.php
+++ b/app/code/community/Freterapido/ProductPageShipping/Model/Config/Source/Position.php
@@ -18,28 +18,28 @@ class Freterapido_ProductPageShipping_Model_Config_Source_Position
 {
     /**
      * Shipping Estimator Positions Map
-     * 
+     *
      * @var Varien_Object
      */
     protected static $_positions = null;
-    
+
     /**
      * Returns list of possible options
-     * 
-     * @return Varien_Object 
+     *
+     * @return Varien_Object
      */
     public static function getPositions()
     {
         if (self::$_positions === null) {
             self::_initPositions();
         }
-        
+
         return self::$_positions;
     }
-    
+
     /**
      * Initializes possible positions for shipping estimator
-     * 
+     *
      */
     protected static function _initPositions()
     {
@@ -61,15 +61,15 @@ class Freterapido_ProductPageShipping_Model_Config_Source_Position
                 'handle' => Freterapido_ProductPageShipping_Model_Config::LAYOUT_HANDLE_CUSTOM
             )
         ));
-        
+
         Mage::dispatchEvent('freterapido_productpageshipping_config_source_position_init', array('positions' => $positions));
-        
+
         self::$_positions = $positions;
     }
-    
+
     /**
      * Returns layout handle name for a shipping estimator position
-     * 
+     *
      * @param string $position
      * @return string
      */
@@ -78,10 +78,10 @@ class Freterapido_ProductPageShipping_Model_Config_Source_Position
         if (($handle = self::getPositions()->getData($position . '/handle'))) {
             return $handle;
         }
-        
+
         return false;
     }
-    
+
     /**
      * Return list of options for the system configuration field.
      * These options indicate the position of the form block on the page
@@ -91,16 +91,14 @@ class Freterapido_ProductPageShipping_Model_Config_Source_Position
     public function toOptionArray()
     {
         $options = array();
-        
+
         foreach (array_keys(self::getPositions()->getData()) as $position) {
             $options[] = array(
-                'value' => $position, 
+                'value' => $position,
                 'label' => self::getPositions()->getData($position . '/label')
             );
         }
-        
+
         return $options;
     }
-    
-    
 }

--- a/app/code/community/Freterapido/ProductPageShipping/Model/Config/Source/Position/Flag.php
+++ b/app/code/community/Freterapido/ProductPageShipping/Model/Config/Source/Position/Flag.php
@@ -18,7 +18,7 @@ class Freterapido_ProductPageShipping_Model_Config_Source_Position_Flag
 {
     /**
      * Returns after flag values for insert method
-     * 
+     *
      * @return array
      */
     public function toOptionArray()

--- a/app/code/community/Freterapido/ProductPageShipping/Model/Estimate.php
+++ b/app/code/community/Freterapido/ProductPageShipping/Model/Estimate.php
@@ -92,13 +92,13 @@ class Freterapido_ProductPageShipping_Model_Estimate
     public function getProduct()
     {
         //Verify if the product is configurable, since configurable products doesn’t have weight to estimate
-        if($this->_product->isConfigurable()){
+        if ($this->_product->isConfigurable()) {
             //For convenience, creates a new variable just for our product
             $configurableProduct = $this->_product;
             //Load an array with all the associated products
             $associated_products = $configurableProduct->loadByAttribute('sku', $configurableProduct->getSku())->getTypeInstance()->getUsedProducts();
             //Run foreach just once to get the first of the associated products
-            foreach($associated_products as $assoc){
+            foreach ($associated_products as $assoc) {
                 $this->_product = $assoc;
                 break;
             }
@@ -180,7 +180,7 @@ class Freterapido_ProductPageShipping_Model_Estimate
 
         if ($product->getStockItem()) {
             $minimumQty = $product->getStockItem()->getMinSaleQty();
-            if($minimumQty > 0 && $request->getQty() < $minimumQty){
+            if ($minimumQty > 0 && $request->getQty() < $minimumQty) {
                 $request->setQty($minimumQty);
             }
         }
@@ -191,8 +191,10 @@ class Freterapido_ProductPageShipping_Model_Estimate
             Mage::throwException($result);
         }
 
-        Mage::dispatchEvent('checkout_cart_product_add_after',
-                            array('quote_item' => $result, 'product' => $product));
+        Mage::dispatchEvent(
+            'checkout_cart_product_add_after',
+            array('quote_item' => $result, 'product' => $product)
+        );
 
         $this->getQuote()->collectTotals();
         $this->_result = $shippingAddress->getGroupedAllShippingRates();

--- a/app/code/community/Freterapido/ProductPageShipping/Model/Observer.php
+++ b/app/code/community/Freterapido/ProductPageShipping/Model/Observer.php
@@ -48,9 +48,11 @@ class Freterapido_ProductPageShipping_Model_Observer
         /* @var $controllerAction Mage_Core_Controller_Varien_Action */
         $controllerAction = $observer->getEvent()->getAction();
         $fullActionName = $controllerAction->getFullActionName();
+
         if ($this->getConfig()->isEnabled() && in_array($fullActionName, $this->getConfig()->getControllerActions())) {
             $position = $this->getConfig()->getDisplayPosition();
             $layoutHandle = $this->getConfig()->getPositionSource()->getLayoutHandleName($position);
+
             if ($layoutHandle) {
                 // Apply shipping estimator position layout handle
                 $controllerAction->getLayout()->getUpdate()->addHandle(

--- a/app/code/community/Freterapido/ProductPageShipping/controllers/EstimateController.php
+++ b/app/code/community/Freterapido/ProductPageShipping/controllers/EstimateController.php
@@ -32,6 +32,7 @@ class Freterapido_ProductPageShipping_EstimateController extends Mage_Catalog_Pr
         $product = $this->_initProduct();
         $this->loadLayout(false);
         $block = $this->getLayout()->getBlock('shipping.estimate.result');
+
         if ($block) {
             $estimate = $block->getEstimate();
             $product->setAddToCartInfo((array) $this->getRequest()->getPost());
@@ -39,6 +40,7 @@ class Freterapido_ProductPageShipping_EstimateController extends Mage_Catalog_Pr
             $addressInfo = $this->getRequest()->getPost('estimate');
             $estimate->setAddressInfo((array) $addressInfo);
             $block->getSession()->setFormValues($addressInfo);
+
             try {
                 $estimate->estimate();
             } catch (Mage_Core_Exception $e) {
@@ -50,6 +52,7 @@ class Freterapido_ProductPageShipping_EstimateController extends Mage_Catalog_Pr
                 );
             }
         }
+
         $this->_initLayoutMessages('catalog/session');
         $this->renderLayout();
     }


### PR DESCRIPTION
Enquanto investigava a possível causa da issue #39, me deparei com alguns pequenos erros de codestyle; daí aproveitei para corrigi-los. Adicionalmente, deixei um .editorconfig na raiz para manter a padronização do codigo. Não há alterações quanto a funcionamento, apenas correções de formatação.