### PR TITLE
Ignorar itens to tipo "bundle" ao fazer a cotação

### DIFF
--- a/app/code/community/Freterapido/Freterapido/Model/Carrier/Freterapido.php
+++ b/app/code/community/Freterapido/Freterapido/Model/Carrier/Freterapido.php
@@ -335,6 +335,10 @@ class Freterapido_Freterapido_Model_Carrier_Freterapido extends Mage_Shipping_Mo
     protected function _getVolumes(Mage_Shipping_Model_Rate_Request $request)
     {
         foreach ($request->getAllItems() as $item) {
+            if ($item->getProductType() == 'bundle') {
+                continue;
+            }
+
             $sku = $item->getProduct()->getSku();
 
             // Recupera os ids das categorias relacionadas ao produto


### PR DESCRIPTION
Na PR #45 foi adicionada compatiblidade com pacotes de produtos, porém o pacote em si estava sendo enviado juntamente com seus respectivos produtos, duplicando valores referentes à medidas/peso.

Esta PR visa remover este item, enviando apenas os produtos em si que o compõem.

Qualquer dúvida/informação adicional, me coloco à disposição. :wink: 